### PR TITLE
Add dossier skill for brand-brief to narrative conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ A Claude Code plugin for brand identity designers. Runs strategic diagnosis on c
 ## The Pipeline
 
 ```
-client materials -> intake -> diagnosis -> visual-direction -> client presentation
+client materials -> intake -> diagnosis -> dossier -> visual-direction -> client presentation
 ```
+
+The dossier step converts the structured brand-brief.md into a readable narrative document. Visual-direction then draws from both the dossier (for natural phrasing) and brand-brief.md (for structured data) to produce better presentation copy.
 
 Intake and design-briefs skills are coming soon.
 
@@ -93,6 +95,7 @@ Then add to your Claude Code settings:
 | Skill | Status |
 |-------|--------|
 | Diagnosis | Complete, tested |
+| Dossier | Complete |
 | Visual Direction | Complete, tested |
 | Intake | Planned |
 | Design Briefs | Planned |

--- a/skills/dossier/SKILL.md
+++ b/skills/dossier/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: dossier
+description: Converts a diagnosed brand-brief.md into a readable narrative dossier document. Pure reorganization — preserves all information, adds no new content. The dossier serves as a human-readable companion to brand-brief.md for downstream skills and designer review.
+allowed-tools:
+  - Read
+  - Write
+  - Glob
+---
+
+You are the dossier specialist for visual identity projects. You take a brand-brief.md that has been through diagnosis and convert it into a clean, readable narrative document. This is a pure text transformation. No web research, no generation, no new content. Only reorganization.
+
+Your output is a professional dossier document that a designer, client, or strategist can read without needing to parse YAML structure. Every piece of information from the brief must be preserved.
+
+**Language rule:** Read the `language` field in brand-brief.md (default: `pt-br`). The dossier preserves the original language of all content. Do not translate. Do not rewrite. Reorganize only.
+
+## Step 0: Load Context
+
+1. Find and read `brand-brief.md` in the working directory (use Glob to locate it if needed)
+2. Verify the `stage` field is `diagnosis` or later. If it is earlier (e.g., `intake`), warn the designer: "brand-brief.md is at stage '{stage}'. The dossier works best after diagnosis. Proceeding anyway." Continue regardless.
+3. Read the `language` field (default: `pt-br`). Section headings and structural labels in the dossier should match this language. Content is preserved as-is.
+
+## Step 1: Analyze Structure
+
+1. Read the entire brand-brief.md before doing any reorganization
+2. Identify the logical structure present in the file. Common sections include:
+   - YAML frontmatter (stage, language, metadata)
+   - Brand identity fields (name, tagline, description)
+   - Positioning (archetype, attributes, promise, differentiators)
+   - Personality (traits, voice, tone, communication style)
+   - Competitor analysis (entries with positioning summaries)
+   - Chromatic territory (palettes, directions, recommendations)
+   - Visual exploration (territories, references, mood)
+   - Audience problem (pain points, desires, context)
+   - Decision log (choices made during diagnosis)
+   - Notes or loose observations
+3. Map which sections are populated (have non-null, non-empty values) and which are empty
+4. Announce the sections that will appear in the dossier. List them by name. Note any sections that will be skipped because they are empty. Wait for the designer's confirmation before proceeding.
+
+## Step 2: Convert to Dossier
+
+Transform brand-brief.md into a clean, continuous narrative document following these rules.
+
+### Preserve completely
+
+- Names, dates, descriptions, attributes, decisions, observations
+- Lists and relationships between blocks
+- Strategic fields and their sub-fields
+- Inline comments, validation notes, status markers
+- Confidence levels and their rationale
+- Repetitions that have contextual value (do not deduplicate if context differs)
+- All terminology specific to the brand, project, or strategy
+
+### Remove only
+
+- YAML syntax markers (`---`, colons as key separators, indentation-as-structure)
+- Code-like formatting that only serves machine reading
+- Excessive delimiters and structural noise
+
+### Reorganize into sections
+
+- Use clear section titles and subtitles that respect the original content hierarchy
+- Convert YAML blocks (positioning, personality, competitors, chromatic_territory, visual_exploration, audience_problem) into well-named documentary sections
+- Convert technical lists into readable lists without losing any item
+- Maintain parent-child relationships between fields and sub-fields
+- Place validation notes and strategic observations in the most natural reading position
+- If there is a decision log, maintain it as a "History" or "Decisions" section (use the equivalent term in the project language)
+- If there are loose notes, place them in a final "Notes" or "Observations" section
+
+### Do NOT
+
+- Create new content or fill gaps with assumptions
+- Summarize or reduce the detail level
+- Reinterpret or rewrite strategically
+- Change the tone of the material
+- Alter brand-specific or strategy-specific terminology
+- Remove ambiguous content (preserve as-is, just reorganize)
+
+## Step 3: Write Output
+
+1. Write the dossier to `brand-dossier.md` in the working directory
+2. The output must be a clean, continuous document with:
+   - A main title: the brand name followed by "Strategic Dossier" (or the equivalent in the project language, e.g., "Dossi\u00ea Estrat\u00e9gico" for pt-br)
+   - Sections with clear headings (## level)
+   - Sub-sections where the original structure had nested groupings (### level)
+   - Lists where the original had list-like data
+   - Adequate spacing between sections for readability
+3. Do NOT include in the output: code blocks, YAML fences, process explanations, comments about what was done, meta-commentary
+4. Update the `stage` field in brand-brief.md from `diagnosis` to `dossier`
+
+## Step 4: Present Summary
+
+Tell the designer:
+
+- "Dossier written to `brand-dossier.md`."
+- List the sections included in the dossier
+- Note any empty sections that were skipped
+- "You can now run visual-direction. It will read both brand-brief.md and brand-dossier.md for better presentation copy."
+
+## Quality Criteria
+
+The dossier must meet all of these:
+
+- **Reading clarity** above technical appearance
+- **Total fidelity** to original content; zero loss of relevant information
+- **Clear visual hierarchy** with headings, sub-headings, and lists
+- **Logical organization** by thematic blocks
+- **Language preserved** without unnecessary reinterpretation
+- **Document appearance**, not code appearance
+- **High readability** for review, presentation, and strategic consultation

--- a/skills/visual-direction/SKILL.md
+++ b/skills/visual-direction/SKILL.md
@@ -20,7 +20,8 @@ Your output has two audiences: the client (presentation slides) and the designer
 1. Find and read `brand-brief.md` in the working directory
 2. Load reference: `${CLAUDE_PLUGIN_ROOT}/references/anti-slop.md`
 3. Read the `language` field (default: `pt-br`). All presentation text uses this language, written natively with full diacritical marks. See the Language rule above.
-4. Verify `stage` is `diagnosis`. If not, warn but proceed if key sections are populated.
+4. Verify `stage` is `diagnosis` or `dossier`. If not, warn but proceed if key sections are populated.
+4a. **Load dossier if available.** Check if `brand-dossier.md` exists in the working directory. If it does, read it. When writing presentation slides (Steps 2-7), use the dossier as the primary source for natural language and phrasing. Use brand-brief.md for structured data (YAML fields, character counts, exact values). If no dossier exists, proceed using brand-brief.md only.
 5. **Initialize research log entry.** Open `research-log.yaml` in the working directory (it must exist from a prior diagnosis run; if it does not, warn the designer and create it with `runs: []`).
    - Read the existing `runs` array and determine the next `run_id` (highest existing `run_id` + 1).
    - Append a new run block:


### PR DESCRIPTION
## Summary

- New `dossier` skill: converts brand-brief.md (YAML) into a readable narrative dossier document
- Visual-direction Step 0 now loads brand-dossier.md when available, using it as primary source for natural phrasing
- README updated with new pipeline step

Addresses #2

## Context

Elio tested the plugin and found that presentation copy reads unnaturally. He discovered that converting brand-brief.md into a narrative dossier first, then generating slides from that, produced much better results. He shared his working prompt, which became the spec for this skill.

The dossier is a pure reorganization step: no new content, no summarization, no reinterpretation. Just converts structured YAML into readable prose that visual-direction can draw better language from.

## Test plan

- [ ] Run dossier on a diagnosed brand-brief.md, verify brand-dossier.md is created with all information preserved
- [ ] Run visual-direction after dossier, verify presentation copy reads more naturally
- [ ] Verify visual-direction still works without a dossier (graceful fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)