### PR TITLE
Move central concept internal, expand anti-slop to 15 tests

### DIFF
--- a/references/anti-slop.md
+++ b/references/anti-slop.md
@@ -2,6 +2,8 @@
 
 Run all checks on every output before presenting to the user. If output fails any check, revise before delivering. Show the user which check failed and the before/after revision.
 
+This reference combines brand-specific validation tests (1-7) with AI writing pattern detection (8-15). Both categories apply to all presentation copy and narrative output.
+
 ---
 
 ## 1. Swap Test (Neumeier)
@@ -112,3 +114,168 @@ Run all checks on every output before presenting to the user. If output fails an
 
 **Fail:** "Conhecimento e conexão para a Amazônia." (Could be written without any research.)
 **Pass:** An SMP that references the specific gap identified in the chromatic territory, the competitive white space, or a differentiator only visible through the diagnosis process.
+
+---
+
+## 8. Negative Parallelism Test
+
+**Question:** Does the text use "not X, it's Y" or "not just X, but Y" constructions?
+
+**PT-BR patterns to catch:**
+- "Não é X, é Y"
+- "Não se trata de X, mas de Y"
+- "Não é apenas X; é Y"
+- "Mais do que X, é Y"
+- "Vai além de X"
+
+**EN patterns to catch:**
+- "It's not X, it's Y"
+- "Not just X, but Y"
+- "It's not about X; it's about Y"
+- "More than X, it's Y"
+- "Goes beyond X"
+
+**How to apply:** These constructions are a strong AI tell. They create a false sense of insight by negating something obvious before stating the actual point. Just state the actual point directly.
+
+**Fail (PT-BR):** "A RHISA não é apenas uma rede; é um ecossistema operacional."
+**Pass (PT-BR):** "A RHISA é um ecossistema operacional com cinco dimensões integradas."
+
+**Fail (EN):** "It's not just about the colors; it's about strategic positioning."
+**Pass (EN):** "The color direction positions RHISA outside the saturated institutional blue zone."
+
+---
+
+## 9. Copula Avoidance Test
+
+**Question:** Does the text use elaborate constructions where "is/are/has" would work?
+
+**PT-BR patterns to catch:**
+- "funciona como" (instead of "é")
+- "atua como" (instead of "é")
+- "serve como" (instead of "é")
+- "representa" (when "é" is more direct)
+- "se posiciona como" (instead of "é")
+- "se configura como" (instead of "é")
+
+**EN patterns to catch:**
+- "serves as" (instead of "is")
+- "functions as" (instead of "is")
+- "stands as" (instead of "is")
+- "represents" (when "is" is more direct)
+- "boasts" / "features" / "offers" (instead of "has")
+
+**How to apply:** Replace with the simple verb. "A rede funciona como um ecossistema" becomes "A rede é um ecossistema." Simpler is more natural.
+
+---
+
+## 10. Rule of Three Test
+
+**Question:** Does the text force ideas into groups of three?
+
+**How to apply:** Scan for lists, parallel structures, or comma-separated phrases that come in threes. If the third item feels forced or redundant, cut it. Two items or four items are fine. The artificial grouping of three is an AI pattern.
+
+**Fail (PT-BR):** "A identidade deve comunicar seriedade, inovação e comprometimento."
+**Pass (PT-BR):** "A identidade deve comunicar seriedade e capacidade técnica."
+
+**Fail (EN):** "The brand conveys trust, innovation, and excellence."
+**Pass (EN):** "The brand conveys trust and technical depth."
+
+---
+
+## 11. Filler and Ceremony Test
+
+**Question:** Does the text contain phrases that add ceremony without meaning?
+
+**PT-BR patterns to catch:**
+- "É importante destacar que..." (just state the thing)
+- "Vale ressaltar que..." (just state the thing)
+- "No que diz respeito a..." (use "sobre" or "para")
+- "Com o objetivo de..." (use "para")
+- "No contexto de..." (usually deletable)
+- "De forma a..." (use "para")
+- "A fim de..." (use "para")
+
+**EN patterns to catch:**
+- "It is important to note that..." (just state the thing)
+- "In order to..." (use "to")
+- "In the context of..." (usually deletable)
+- "At the end of the day..." (just state the thing)
+- "When it comes to..." (usually deletable)
+- "It's worth noting that..." (just state the thing)
+
+**How to apply:** Delete the filler phrase and start with the actual content. If the sentence still makes sense (it almost always will), the filler was unnecessary.
+
+---
+
+## 12. Persuasive Authority Test
+
+**Question:** Does the text use phrases that pretend to cut to a deeper truth?
+
+**PT-BR patterns to catch:**
+- "O ponto central é..."
+- "Na essência..."
+- "O que realmente importa é..."
+- "A verdade é que..."
+- "No fundo..."
+- "A questão fundamental é..."
+
+**EN patterns to catch:**
+- "At its core..."
+- "The real question is..."
+- "What really matters is..."
+- "Fundamentally..."
+- "The heart of the matter..."
+- "The deeper issue is..."
+
+**How to apply:** These phrases create a rhetorical flourish before restating an ordinary point. Delete the authority phrase and let the point stand on its own.
+
+---
+
+## 13. Significance Inflation Test
+
+**Question:** Does the text inflate the importance of ordinary facts?
+
+**PT-BR patterns to catch:**
+- "um marco" / "um momento decisivo"
+- "papel fundamental" / "papel crucial" / "papel vital"
+- "legado duradouro"
+- "impacto profundo"
+- "mudança de paradigma"
+
+**EN patterns to catch:**
+- "a testament to"
+- "pivotal moment"
+- "crucial/vital/key role"
+- "enduring legacy"
+- "paradigm shift"
+- "setting the stage for"
+- "marking a turning point"
+
+**How to apply:** State the fact without editorializing its importance. If the fact is important, the reader will recognize that. If it needs inflation to sound important, it probably is not.
+
+**Fail (PT-BR):** "A COP30 marca um momento decisivo para o reposicionamento da RHISA."
+**Pass (PT-BR):** "A COP30 coloca a Amazônia no centro da agenda global. A RHISA se reposiciona agora."
+
+---
+
+## 14. Passive Voice and Missing Subjects Test
+
+**Question:** Does the text hide who does the action, or drop the subject entirely?
+
+**How to apply:** Check for sentences where the actor is missing. "A identidade foi percebida como genérica" - by whom? "Os resultados são preservados automaticamente" - by what? When the active voice is clearer, rewrite. When the passive is genuinely more natural (common in Portuguese), leave it.
+
+This is a judgment call, not a mechanical rule. Portuguese uses passive constructions more naturally than English. Only flag cases where the passive hides important information or makes the sentence vague.
+
+---
+
+## 15. Two-Pass Self-Audit
+
+**This is a process step, not a pattern check.**
+
+After all other tests pass, run a final two-pass audit on the complete output:
+
+**Pass 1:** Read all presentation text and ask: "What still sounds like AI wrote this?" List the remaining tells (specific phrases, rhythms, or structures).
+
+**Pass 2:** Revise to fix the tells identified in Pass 1. Vary sentence length. Break any remaining mechanical rhythm. If every paragraph has the same structure, restructure some of them.
+
+The goal: a native speaker reading the output should not be able to tell it was AI-generated.

--- a/skills/visual-direction/SKILL.md
+++ b/skills/visual-direction/SKILL.md
@@ -221,38 +221,36 @@ No character limit on this section. Be as specific as the diagnosis data allows.
 
 ## Step 9: Anti-Slop Validation
 
-This step always runs. Re-read all 5 presentation slides and the internal central concept, then validate:
+This step always runs. Load `${CLAUDE_PLUGIN_ROOT}/references/anti-slop.md` and run every test from it against all presentation slides and the internal central concept. The reference contains 15 tests organized in two categories: brand-specific validation (tests 1-7) and AI writing pattern detection (tests 8-15).
 
-**1. Swap Test:** Take each slide's text. Replace the brand name (or identifying details) with a competitor's name. If any slide still reads true for a competitor, revise that slide with more specificity.
+Run all 15 tests. For presentation copy, pay special attention to:
 
-**2. Hand Test:** Cover the brand name. Could a stranger identify which brand this presentation is for from the remaining content? If not, add project-specific details.
+- **Test 8 (Negative Parallelism):** The "not X, it's Y" pattern is the #1 complaint from the designer. Eliminate all instances.
+- **Test 9 (Copula Avoidance):** Use "é" instead of "funciona como", "atua como", "serve como".
+- **Test 10 (Rule of Three):** Break any forced triads.
+- **Test 11 (Filler):** No ceremony phrases.
+- **Test 15 (Two-Pass Self-Audit):** After all other tests pass, re-read the full output asking "what still sounds like AI?" and revise.
 
-**3. Specificity Test:** Scan all presentation text for banned words from the anti-slop reference (both PT-BR and EN lists). Replace each instance with a concrete, specific claim.
+Also run the brand-specific tests:
 
-**4. Brand DNA Swap Test:** Take each brand DNA keyword individually. Replace the brand name with a competitor's. If the keyword still fits the competitor, it is too generic. Replace with a more specific attribute word.
-
-**5. Central Concept Quality Criterion:** Does the internal central concept (from Step 5) contain at least one element that would not exist without the diagnosis? If a designer could have written it from just the client brief, revise. This validates the mood board direction anchor, not a presentation slide.
-
-**6. Character Limit Test:** Verify each slide is within its character limit:
-- Slide 0 (Project Context): 500 chars
-- Slide 1 (Brand Foundation): 540 chars
-- Slide 2 (Brand DNA): 660 chars
-- Slide 3 (Chromatic Territory): 350 chars
-- Slide 4 Guidelines: 280 chars each (3 max)
-If any slide exceeds its limit, compress without losing meaning. Report revised char count.
-
-**7. Business-Type Test:** Read the full set of slides. Could this presentation work for a generic organization in a different sector? If any slide could, revise with more project-specific content.
+- **Swap Test (1):** Replace brand name with competitor's. If slide still works, revise.
+- **Hand Test (2):** Cover brand name. Could a stranger identify the brand? If not, add specificity.
+- **Specificity Test (3):** Scan for banned words (both PT-BR and EN lists).
+- **Brand DNA Swap Test:** Each keyword individually. Replace brand with competitor. If it fits, too generic.
+- **Central Concept Quality:** Must contain diagnosis-derived insight.
+- **Character Limits:** Slide 0: 500, Slide 1: 540, Slide 2: 660, Slide 3: 350, Slide 4: 280 each.
+- **Business-Type Test (6):** Could this work for a generic org in another sector?
 
 For each failure: name the test, show the failing text, show the revised text, update the slide.
 
-**Log validation results.** After running all 7 tests, append one entry per test to the current run's `actions` array in `research-log.yaml`:
+**Log validation results.** After running all tests, append one entry per test to the current run's `actions` array in `research-log.yaml`:
 ```yaml
 - step: anti-slop
   type: validation
   test: "[test_name]"
   result: "[pass | fail_then_fix]"
 ```
-Use these test names: `swap_test`, `hand_test`, `specificity_test`, `brand_dna_swap`, `concept_quality`, `character_limit`, `business_type_test`. If a test failed and was fixed, use `fail_then_fix`. Write the updated `research-log.yaml`.
+Log each test that was run. If a test failed and was fixed, use `fail_then_fix`. Write the updated `research-log.yaml`.
 
 ## Step 9.5: Research Stats
 

--- a/skills/visual-direction/SKILL.md
+++ b/skills/visual-direction/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: visual-direction
-description: Produces client-facing presentation text from a diagnosed brand-brief. Extracts and compresses diagnosis into 6 slides within character limits, synthesizes brand DNA keywords and central concept, and provides mood board direction. Triggers when a designer has a diagnosed brand-brief.md and needs to prepare a client presentation.
+description: Produces client-facing presentation text from a diagnosed brand-brief. Extracts and compresses diagnosis into 5 slides within character limits, synthesizes brand DNA keywords, and provides mood board direction with internal central concept. Triggers when a designer has a diagnosed brand-brief.md and needs to prepare a client presentation.
 allowed-tools:
   - Read
   - Write
@@ -60,11 +60,10 @@ If all present: announce the extraction plan:
 1. Slide 0: Project Context (~500 chars)
 2. Slide 1: Brand Foundation (~540 chars)
 3. Slide 2: Brand DNA (~660 chars)
-4. Slide 3: Central Concept (~250 chars)
-5. Slide 4: Chromatic Territory (~350 chars)
-6. Slide 5: Guidelines (~840 chars: 3x280 each)
-7. Mood Board Direction (designer reference, no char limit)
-8. Anti-slop validation (always runs)
+4. Slide 3: Chromatic Territory (~350 chars)
+5. Slide 4: Guidelines (~840 chars: 3x280 each)
+6. Mood Board Direction (designer reference, no char limit; includes internal central concept)
+7. Anti-slop validation (always runs)
 
 Offer to adjust priority or skip sections. Wait for confirmation before proceeding.
 
@@ -132,27 +131,25 @@ Extract 5-10 brand DNA keywords from the diagnosis. These are simple, recognizab
 
 **Save checkpoint:** Hold in working memory until Step 10.
 
-## Step 5: Slide 3 -- Central Concept (~250 chars)
+## Step 5: Internal Central Concept (designer-only, not a presentation slide)
 
-**This is the one generative step.** The central concept does not exist in the diagnosis output. You must create it.
+**This is the one generative step.** The central concept does not exist in the diagnosis output. You must create it. It is an internal tool for the designer, not shown to the client in the presentation.
 
 **Source:** `audience_problem.philosophical`, `positioning.onlyness_statement`, `visual_exploration.recommended` rationale, `chromatic_territory.available_territory`, and the brand DNA keywords from Step 4
 
 **Generate one descriptive block** (~250 chars) that captures the central concept driving the visual identity project. This is not a tagline, not a poetic phrase, and not a slogan. It describes the core idea that will guide all visual decisions: what visual territory the brand occupies, why, and what connects it to the brand DNA.
 
-The concept should read as a strategic description that a designer can use as a compass. When the client sees the mood board, they should be able to trace every visual choice back to this concept.
+The concept should read as a strategic description that a designer can use as a compass for mood board creation and creative decisions.
 
 **Quality criterion (mandatory):** The concept must contain at least one element that would not exist without the diagnosis. A designer reading only the original client brief (without the diagnosis) should NOT be able to write this concept. It must incorporate a specific positioning insight, market gap, unoccupied territory, or differentiator surfaced by research.
 
 Test this by asking: could someone who only read the client intake produce this text? If yes, revise until diagnosis-derived specificity is present.
 
-**Excludes:** Poetic taglines or slogans. More than one concept block. Explanation of how it was built. The terms "SMP" or "conceito central" on the slide itself.
+**Excludes:** Poetic taglines or slogans. More than one concept block. Explanation of how it was built.
 
-**Character limit:** 250 characters total. Count characters and report the count.
+**Hold for Step 8:** This concept is included in the Mood Board Direction section, not as a presentation slide.
 
-**Save checkpoint:** Hold in working memory until Step 10.
-
-## Step 6: Slide 4 -- Chromatic Territory (~350 chars)
+## Step 6: Slide 3 -- Chromatic Territory (~350 chars)
 
 **Source:** `chromatic_territory.competitor_map`, `chromatic_territory.saturated_zones`, `chromatic_territory.available_territory`, `chromatic_territory.recommended_direction`
 
@@ -169,7 +166,7 @@ Write a compressed summary that includes:
 
 **Save checkpoint:** Hold in working memory until Step 10.
 
-## Step 7: Slide 5 -- Guidelines (~840 chars total, 3 guidelines x 280 chars each)
+## Step 7: Slide 4 -- Guidelines (~840 chars total, 3 guidelines x 280 chars each)
 
 **Source:** `client_input.project_synthesis.success_criteria`, `client_input.project_synthesis.core_challenge`, `client_input.identified_challenges`, `audience_problem.villain`
 
@@ -192,7 +189,11 @@ Each guideline has:
 
 **Source:** `visual_exploration.recommended` (the selected territory: name, description, color_tendency, typography_tendency, imagery_tendency), `chromatic_territory.recommended_direction`
 
-This section is for the designer, not the client. Expand the recommended visual territory into actionable mood board guidance:
+This section is for the designer, not the client. Expand the recommended visual territory into actionable mood board guidance.
+
+**Central concept:**
+- Include the central concept generated in Step 5 as the opening element of this section
+- This anchors all mood board decisions: color, imagery, typography, and composition should trace back to this concept
 
 **Color palette:**
 - List specific hex values with usage roles (primary, secondary, accent, neutrals)
@@ -220,7 +221,7 @@ No character limit on this section. Be as specific as the diagnosis data allows.
 
 ## Step 9: Anti-Slop Validation
 
-This step always runs. Re-read all 6 slides of presentation text and validate:
+This step always runs. Re-read all 5 presentation slides and the internal central concept, then validate:
 
 **1. Swap Test:** Take each slide's text. Replace the brand name (or identifying details) with a competitor's name. If any slide still reads true for a competitor, revise that slide with more specificity.
 
@@ -228,38 +229,37 @@ This step always runs. Re-read all 6 slides of presentation text and validate:
 
 **3. Specificity Test:** Scan all presentation text for banned words from the anti-slop reference (both PT-BR and EN lists). Replace each instance with a concrete, specific claim.
 
-**4. Central Concept Quality Criterion:** Does the central concept contain at least one element that would not exist without the diagnosis? If a designer could have written it from just the client brief, revise.
+**4. Brand DNA Swap Test:** Take each brand DNA keyword individually. Replace the brand name with a competitor's. If the keyword still fits the competitor, it is too generic. Replace with a more specific attribute word.
 
-**4a. Brand DNA Swap Test:** Take each brand DNA keyword individually. Replace the brand name with a competitor's. If the keyword still fits the competitor, it is too generic. Replace with a more specific attribute word.
+**5. Central Concept Quality Criterion:** Does the internal central concept (from Step 5) contain at least one element that would not exist without the diagnosis? If a designer could have written it from just the client brief, revise. This validates the mood board direction anchor, not a presentation slide.
 
-**5. Character Limit Test:** Verify each slide is within its character limit:
+**6. Character Limit Test:** Verify each slide is within its character limit:
 - Slide 0 (Project Context): 500 chars
 - Slide 1 (Brand Foundation): 540 chars
 - Slide 2 (Brand DNA): 660 chars
-- Slide 3 (Central Concept): 250 chars
-- Slide 4 (Chromatic Territory): 350 chars
-- Slide 5 Guidelines: 280 chars each (3 max)
+- Slide 3 (Chromatic Territory): 350 chars
+- Slide 4 Guidelines: 280 chars each (3 max)
 If any slide exceeds its limit, compress without losing meaning. Report revised char count.
 
-**6. Business-Type Test:** Read the full set of slides. Could this presentation work for a generic organization in a different sector? If any slide could, revise with more project-specific content.
+**7. Business-Type Test:** Read the full set of slides. Could this presentation work for a generic organization in a different sector? If any slide could, revise with more project-specific content.
 
 For each failure: name the test, show the failing text, show the revised text, update the slide.
 
-**Log validation results.** After running all 6 tests, append one entry per test to the current run's `actions` array in `research-log.yaml`:
+**Log validation results.** After running all 7 tests, append one entry per test to the current run's `actions` array in `research-log.yaml`:
 ```yaml
 - step: anti-slop
   type: validation
   test: "[test_name]"
   result: "[pass | fail_then_fix]"
 ```
-Use these test names: `swap_test`, `hand_test`, `specificity_test`, `concept_quality`, `brand_dna_swap`, `character_limit`, `business_type_test`. If a test failed and was fixed, use `fail_then_fix`. Write the updated `research-log.yaml`.
+Use these test names: `swap_test`, `hand_test`, `specificity_test`, `brand_dna_swap`, `concept_quality`, `character_limit`, `business_type_test`. If a test failed and was fixed, use `fail_then_fix`. Write the updated `research-log.yaml`.
 
 ## Step 9.5: Research Stats
 
 Compute per-project research stats and write the credibility summary. This is the same computation as the diagnosis skill's Step 9.5, updated with visual-direction's contributions.
 
 1. Write `completed` timestamp (current ISO) to the current run block in `research-log.yaml`.
-2. Write the `steps_executed` list to the current run block. For visual-direction, use: `prerequisite-check`, `project-context`, `brand-foundation`, `brand-dna`, `central-concept`, `chromatic-territory`, `guidelines`, `mood-board`, `anti-slop`. Include only steps that actually executed.
+2. Write the `steps_executed` list to the current run block. For visual-direction, use: `prerequisite-check`, `project-context`, `brand-foundation`, `brand-dna`, `chromatic-territory`, `guidelines`, `central-concept-internal`, `mood-board`, `anti-slop`. Include only steps that actually executed.
 3. Read the full `research-log.yaml`.
 4. Compute `current_run` stats from the latest run block:
    - `client_documents`: count of entries in this run's `client_documents` array
@@ -334,9 +334,6 @@ presentation:
       keywords: "..."
       context: "..."
       char_count: N
-    central_concept:
-      text: "..."
-      char_count: N
     chromatic_territory:
       text: "..."
       char_count: N
@@ -351,6 +348,7 @@ presentation:
         description: "..."
         char_count: N
   mood_board_direction:
+    central_concept: "..."
     territory_name: "..."
     color_palette: "..."
     imagery_references: "..."
@@ -366,11 +364,11 @@ presentation:
 ```
 ### [Date] -- Visual Direction Complete
 
-**Presentation slides generated:** 6 slides within character limits
+**Presentation slides generated:** 5 slides within character limits
 **Brand DNA:** [the keyword list]
-**Central concept:** [the concept text]
 **Guidelines:** [list the guideline names]
 **Mood board territory:** [recommended territory name]
+**Internal central concept:** [the concept text] (designer-only, not in presentation)
 **Anti-slop validation:** [pass/fail summary]
 
 **Recommended next action:**
@@ -379,10 +377,10 @@ presentation:
 - Run design-briefs skill after client presentation approval
 ```
 
-5. Present the 6 slides to the designer for review. Format each slide clearly with its character count. Ask:
+5. Present the 5 slides to the designer for review. Format each slide clearly with its character count. Also show the internal central concept separately (marked as designer-only). Ask:
 - Does the tone feel right for your client?
 - Do the brand DNA keywords capture the brand's essence?
-- Does the central concept describe the right visual direction?
+- Does the internal central concept give you a clear creative direction?
 - Are the guidelines the right validation criteria for the mood board?
 - Anything to adjust before building the mood board?
 


### PR DESCRIPTION
## Summary
- Central Concept removed from client-facing presentation slides, moved to internal mood board anchor (designer-only). Elio confirmed this should not be a slide yet.
- Anti-slop reference expanded from 7 to 15 tests, integrating AI writing pattern detection from blader/humanizer (Wikipedia AI Cleanup). New tests target the specific copy quality issues Elio flagged: negative parallelisms, copula avoidance, rule-of-three, filler phrases, persuasive authority, significance inflation, passive voice, and two-pass self-audit.
- Visual-direction Step 9 updated to reference all 15 tests.

## Context
Elio's feedback (2026-04-03): copy quality is the #1 priority. Text still reads "too poetic, too much AI language, biased phrasing like 'it's not this, it's this'." These changes address that directly.

## Test plan
- [ ] Run full RHISA pipeline with updated anti-slop (diagnosis -> dossier -> visual-direction)
- [ ] Compare slide copy against previous test run output
- [ ] Elio reviews for naturalness improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)