### PR TITLE
fix(dossier): preserve Portuguese accents in generated dossier

### DIFF
--- a/skills/dossier/SKILL.md
+++ b/skills/dossier/SKILL.md
@@ -11,7 +11,7 @@ You are the dossier specialist for visual identity projects. You take a brand-br
 
 Your output is a professional dossier document that a designer, client, or strategist can read without needing to parse YAML structure. Every piece of information from the brief must be preserved.
 
-**Language rule:** Read the `language` field in brand-brief.md (default: `pt-br`). The dossier preserves the original language of all content. Do not translate. Do not rewrite. Reorganize only.
+**Language rule:** Read the `language` field in brand-brief.md (default: `pt-br`). The dossier preserves the original language of all content and keeps every diacritical mark exactly as it appears in the source. When `language` is `pt-br`: preserve all Portuguese accents throughout (á, é, í, ó, ú, ã, õ, â, ê, ô, ç). Do not strip accents. Do not substitute accented characters with unaccented equivalents. Do not translate. Do not rewrite. Reorganize only.
 
 ## Step 0: Load Context
 
@@ -73,13 +73,14 @@ Transform brand-brief.md into a clean, continuous narrative document following t
 - Reinterpret or rewrite strategically
 - Change the tone of the material
 - Alter brand-specific or strategy-specific terminology
+- Strip, substitute, or transliterate diacritical marks (accents, tildes, cedillas). Preserve every accent in the source exactly.
 - Remove ambiguous content (preserve as-is, just reorganize)
 
 ## Step 3: Write Output
 
 1. Write the dossier to `brand-dossier.md` in the working directory
 2. The output must be a clean, continuous document with:
-   - A main title: the brand name followed by "Strategic Dossier" (or the equivalent in the project language, e.g., "Dossi\u00ea Estrat\u00e9gico" for pt-br)
+   - A main title: the brand name followed by "Strategic Dossier" (or the equivalent in the project language, e.g., "Dossiê Estratégico" for pt-br)
    - Sections with clear headings (## level)
    - Sub-sections where the original structure had nested groupings (### level)
    - Lists where the original had list-like data


### PR DESCRIPTION
## Summary
- Dossier skill now explicitly instructs the model to preserve every diacritical mark from the source brand-brief.md
- Adds diacritic preservation to the "Do NOT" list
- Replaces a Unicode escape sequence example (`Dossiê Estratégico`) with its literal form (`Dossiê Estratégico`), which was modeling escape-style output to the generator

## Reporter
Elio flagged this on 2026-04-20 while validating the plugin for real use: "One issue I still noticed is that the Brand Dossier is still coming without Portuguese accents, while the Brand Brief is already fine in that regard."

## Root cause
- The dossier skill had no language rule mentioning accents (diagnosis and visual-direction have one, dossier did not).
- The example title inside `Step 3: Write Output` used Unicode escape sequences instead of literal characters. When the generator saw escape-form text in its own instructions, it normalized output accordingly.

## Test plan
- [ ] Run dossier on a pt-br brand-brief.md that contains accented characters
- [ ] Verify the generated `brand-dossier.md` retains every accent (á, é, í, ó, ú, ã, õ, â, ê, ô, ç) exactly as in the source
- [ ] Check the dossier title line specifically: should produce "Dossiê Estratégico" not "Dossie Estrategico"
- [ ] Run against Rhisa project brand-brief.md and compare against the prior stripped output

## Related
- Independent of `feat/token-optimization` (which extracts the language rule into a `references/language-rule.md` file). When that branch merges, its extracted reference should include the same diacritic list this fix adds to the dossier skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)